### PR TITLE
Various tweaks, improvements & adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 MQMitsi
 =======
-Copyright 2015 Hadley Rich  
+Copyright 2015-2017 Hadley Rich  
 Website: <http://nice.net.nz>
 
 Python scripts to interface with a Mitsubishi Heat Pump / Air Conditioner
@@ -8,6 +8,141 @@ Python scripts to interface with a Mitsubishi Heat Pump / Air Conditioner
 Includes a module for UART communication with the unit itself, and also a module for interfacing through MQTT.
 
 A work in progress. There are a couple of issues and missing things.
+
+Example Usage
+-------------
+
+
+On its own, `mitsi.py` doesn't do a lot. Invoking it directly will enabled `DEBUG` logging, and simply output the details of any messages received from the heatpump.
+
+```bash
+~: ./miysi.py /dev/ttyAMA0
+HP Packet: 0x7a : 00 : 0x54
+Temp packet: 20
+HP Packet: 0x62 : 03,00,00,0a,00,00,a8,00,00,00,00,00,00,00,00,00 : 0xa8
+Set Packet: [('power', 'ON'), ('mode', 'COOL'), ('temp', 20), ('fan', 'AUTO'), ('vane', 'AUTO'), ('dir', '|')]
+HP Packet: 0x62 : 02,00,00,01,03,0b,00,00,00,00,03,a8,00,00,00,00 : 0xa1
+Temp packet: 20
+Set Packet: [('power', 'ON'), ('mode', 'COOL'), ('temp', 20), ('fan', 'AUTO'), ('vane', 'AUTO'), ('dir', '|')]
+Temp packet: 20
+Set Packet: [('power', 'ON'), ('mode', 'COOL'), ('temp', 20), ('fan', 'AUTO'), ('vane', 'AUTO'), ('dir', '|')]
+Temp packet: 20
+Set Packet: [('power', 'ON'), ('mode', 'COOL'), ('temp', 20), ('fan', 'AUTO'), ('vane', 'AUTO'), ('dir', '|')]
+Temp packet: 20
+^CExiting.
+```
+
+`mitsi.py` is best used as a library in other scripts. Here's a basic example of connecting to the heatpump, then watching & modifying its state.
+
+```python
+from mitsi import HeatPump
+from time import sleep
+
+# Create our HeatPump object, and start the serial connection
+heatpump = HeatPump('/dev/ttyAMA0')
+heatpump.connect()
+
+# Function to watch the heatpump for 10 seconds, and print the current state
+# when a valid packet is found.
+def watch_heatpump():
+  for i in range(10):
+      heatpump.loop()
+      if heatpump.valid:
+          print(heatpump.to_dict())
+      sleep(1)
+
+# Let's see the current state of the heatpump.
+watch_heatpump()
+
+# Now set the heatpump's target temperature to 22, and the fan to cooling mode.
+heatpump.set({'temp':'22', 'mode': 'COOL'})
+
+# Check the changes have taken effect.
+watch_heatpump()
+
+# Now switch off the heatpump.
+heatpump.set({'power': 'OFF'})
+
+# And watch for the heatpump to switch off.
+watch_heatpump()
+```
+
+### MQTT Bridge ###
+
+`mqmitsi` is a bridge between an MQTT broker and the `mitsi.py` library. It publishes the current state of the heatpump to the broker, and listens for state change requests. It's a very simple way of remotely controlling the heatpump.
+
+```bash
+# Example bridge between /dev/ttyAMA0 and the local MQTT broker.
+~: ./mqmitsi --serial-port /dev/ttyAMA0 --mqtt-host localhost --mqtt-prefix 'heatpump' --log DEBUG
+2017-06-07 04:23:05,927 INFO     Connected to MQTT broker: hassbian
+2017-06-07 04:23:06,944 DEBUG    HP Packet: 0x7a : 00 : 0x54
+2017-06-07 04:23:07,959 DEBUG    Temp Packet: 21
+2017-06-07 04:23:07,962 DEBUG    HP Packet: 0x62 : 03,00,00,0b,00,00,aa,00,00,00,00,00,00,00,00,00 : 0xa5
+2017-06-07 04:23:08,979 DEBUG    Set Packet: [('power', 'OFF'), ('mode', 'COOL'), ('temp', 22), ('fan', 'AUTO'), ('vane', 'AUTO'), ('dir', '|')]  
+2017-06-07 04:23:08,996 DEBUG    HP Packet: 0x62 : 02,00,00,00,03,09,00,00,00,00,03,ac,00,00,00,00 : 0xa0
+2017-06-07 04:23:10,020 DEBUG    Temp Packet: 21
+2017-06-07 04:23:11,028 DEBUG    Set Packet: [('power', 'OFF'), ('mode', 'COOL'), ('temp', 22), ('fan', 'AUTO'), ('vane', 'AUTO'), ('dir', '|')]  
+2017-06-07 04:23:12,034 DEBUG    Temp Packet: 21
+2017-06-07 04:23:13,041 DEBUG    Set Packet: [('power', 'OFF'), ('mode', 'COOL'), ('temp', 22), ('fan', 'AUTO'), ('vane', 'AUTO'), ('dir', '|')]  
+2017-06-07 04:23:14,047 DEBUG    Temp Packet: 21
+2017-06-07 04:23:15,055 DEBUG    Set Packet: [('power', 'OFF'), ('mode', 'COOL'), ('temp', 22), ('fan', 'AUTO'), ('vane', 'AUTO'), ('dir', '|')]
+^C2017-06-07 04:23:15,912 WARNING  Disonnected from MQTT broker: hassbian
+```
+
+#### Quick MQTT Introduction ####
+
+
+If you're not familiar with MQTT, it's very easy to get started with. You can be up and running in 5 minutes, remotely controlling your heatpump. Firstly install the mosquitto mqtt broker server & cli tools.
+
+```bash
+# On Debian & Ubuntu
+~: sudo apt install mosquitto mosquitto-clients
+```
+
+**Note:** by default mosquitto will bind to `*:1883`, so make sure you don't accidentally expose it to the internet.
+
+##### Subscribing to Current State #####
+
+
+The `mosquitto_sub` command let you subscribe to a specific mqtt topic, just like `mqmitsi` does internally. There are two topics:
+
+ - **$prefix/connected** - is the bridge actively connected to the heatpump (*bool*).
+ - **$prefix/state** - the data the heatpump is announcing (*json string*).
+
+`$prefix` will match whatever `--mqtt-prefix` value you gave `mqmitsi`.
+
+```bash
+~: mosquitto_sub -t heatpump/state
+{"power": "ON", "temp": 18.5, "vane": "AUTO", "mode": "COOL", "fan": "AUTO", "dir": "|", "room_temp": 17}
+```
+
+For development and troubleshooting is useful to subscribe to all topics the broker has. This can be done using the "#" topic name.
+
+```bash
+~: mosquitto_sub -t "#" -v
+heatpump_upstairs/connected 1
+heatpump_upstairs/state {"power": "ON", "temp": 18.5, "vane": "AUTO", "mode": "COOL", "fan": "AUTO", "dir": "|", "room_temp": 17}
+```
+
+##### Changing State #####
+
+To issue a command to the heatpump, you can use `mosquitto_pub` to manually publish a command to the topic. There's just a single topic to do this:
+
+ - **$prefix/command/state** - new values to set (*json string*).
+
+```bash
+~: mosquitto_pub -h localhost -t "heatpump/command/state" -m '{"power":"ON", "temp": 16, "mode": "COOL"}
+```
+
+When in debug mode, the log of `mqmitsi` will show:
+```bash
+[...]
+2017-06-07 04:27:51,711 DEBUG    MQTT Message: heatpump/command/state : {"power": "ON", "temp": "18.0"}
+2017-06-07 04:27:52,826 DEBUG    Sending packet: 0x41 : 01,04,00,00,00,0d,00,00,00,00,00,00,00,00,00,00 : 0x6c
+[...]
+```
+
+*Note:* Any values you don't provide will remain as they currently are.
 
 Issues
 ------
@@ -17,10 +152,10 @@ Issues
 - Due to the way that the heat pump communicates (slowly) you may not see a result from sending a command for a few seconds.
 - There are others I haven't thought of yet - it's only been tested on two models under our own use cases.
 
+
 Wanted / TODO
 -------------
 
-- Documentation and examples.
 - More robust reconnection to MQTT broker.
 - Figure out the codes for horizontal vanes.
 - Implement more MQTT connection options
@@ -32,4 +167,3 @@ Wanted / TODO
 LICENSE
 -------
 BSD - See LICENSE file
-

--- a/mitsi_lookup.py
+++ b/mitsi_lookup.py
@@ -1,0 +1,143 @@
+
+class LookupDict(dict):
+    def __init__(self, d, name='unknown'):
+        super(self.__class__, self).__init__(d)
+        self.name = name
+
+    def lookup(self, value):
+        try:
+            ret = [k for k, v in self.items() if v == value][0]
+        except:
+            ret = None
+            log.error('Failed to lookup %s from %s' % (value, self.name))
+        return ret
+
+POWER = LookupDict({
+    'OFF': 0x00,
+    'ON': 0x01,
+}, 'POWER')
+
+TEMP = LookupDict({
+    31: 0x00,
+    30: 0x01,
+    29: 0x02,
+    28: 0x03,
+    27: 0x04,
+    26: 0x05,
+    25: 0x06,
+    24: 0x07,
+    23: 0x08,
+    22: 0x09,
+    21: 0x0a,
+    20: 0x0b,
+    19: 0x0c,
+    18: 0x0d,
+    17: 0x0e,
+    16: 0x0f,
+    16.5: 0x1f,
+    17.5: 0x1e,
+    18.5: 0x1d,
+    19.5: 0x1c,
+    20.5: 0x1b,
+    21.5: 0x1a,
+    22.5: 0x19,
+    23.5: 0x18,
+    24.5: 0x17,
+    25.5: 0x16,
+    26.5: 0x15,
+    27.5: 0x14,
+    28.5: 0x13,
+    29.5: 0x12,
+    30.5: 0x11,
+    31.5: 0x10,
+}, 'TEMP')
+
+ROOM_TEMP = LookupDict({
+    10: 0x00,
+    11: 0x01,
+    12: 0x02,
+    13: 0x03,
+    14: 0x04,
+    15: 0x05,
+    16: 0x06,
+    17: 0x07,
+    18: 0x08,
+    19: 0x09,
+    20: 0x0a,
+    21: 0x0b,
+    22: 0x0c,
+    23: 0x0d,
+    24: 0x0e,
+    25: 0x0f,
+    26: 0x10,
+    27: 0x11,
+    28: 0x12,
+    29: 0x13,
+    30: 0x14,
+    31: 0x15,
+    32: 0x16,
+    33: 0x17,
+    34: 0x18,
+    35: 0x19,
+    36: 0x1a,
+    37: 0x1b,
+    38: 0x1c,
+    39: 0x1d,
+    40: 0x1e,
+    41: 0x1f,
+}, 'ROOM_TEMP')
+
+MODE = LookupDict({
+    'HEAT': 0x01,
+    'DRY': 0x02,
+    'COOL': 0x03,
+    'FAN': 0x07,
+    'AUTO': 0x08,
+}, 'MODE')
+
+VANE = LookupDict({
+    'AUTO': 0x00,
+    '1': 0x01,
+    '2': 0x02,
+    '3': 0x03,
+    '4': 0x04,
+    '5': 0x05,
+    'SWING': 0x07,
+}, 'VANE')
+
+DIR = LookupDict({
+    '<<': 0x01,
+    '<': 0x02,
+    '|': 0x03,
+    '>': 0x04,
+    '>>': 0x05,
+    '<>': 0x08,
+    'SWING': 0x0c,
+}, 'DIR')
+
+FAN = LookupDict({
+    'AUTO': 0x00,
+    'QUIET': 0x01,
+    '1': 0x02,
+    '2': 0x03,
+    '3': 0x05,
+    '4': 0x06,
+}, 'FAN')
+
+CONTROL_PACKET_VALUES = LookupDict({
+    'POWER': 0x01,
+    'MODE': 0x02,
+    'TEMP': 0x04,
+    'FAN': 0x08,
+    'VANE': 0x10,
+    'DIR': 0x80,
+}, 'CONTROL_PACKET_VALUES')
+
+CONTROL_PACKET_POSITIONS = LookupDict({
+    'POWER': 3,
+    'MODE': 4,
+    'TEMP': 5,
+    'FAN': 6,
+    'VANE': 7,
+    'DIR': 10,
+}, 'CONTROL_PACKET_POSITIONS')

--- a/mqmitsi
+++ b/mqmitsi
@@ -7,11 +7,12 @@ import signal
 import logging
 import argparse
 import paho.mqtt.client as mqtt
-from mitsi import *
+from mitsi import HeatPump
 
 
 class Handler(object):
-    def __init__(self, serial_port, broker, prefix, user=None, password=None):
+    def __init__(self, serial_port, broker, broker_port,
+                 prefix, user=None, password=None):
         self.running = True
         self.prefix = prefix
         signal.signal(signal.SIGINT, self.cleanup)
@@ -27,7 +28,7 @@ class Handler(object):
         self.client.will_set(will_topic, '0', qos=1, retain=True)
         self.client.on_connect = self.on_connect
         self.client.on_message = self.on_message
-        self.client.connect(broker)
+        self.client.connect(broker, port=broker_port)
         self.publish('connected', 1, qos=1, retain=True)
         self.connected_state = 1
         self.client.subscribe('%s/command/#' % prefix)
@@ -71,7 +72,10 @@ class Handler(object):
                     state = json.loads(msg.payload)
                 except ValueError:
                     log.warning('Invalid JSON: %s' % msg.payload)
-                self.hp.set(state)
+                try:
+                    self.hp.set(state)
+                except:
+                    log.error('Failed to set')
 
     def cleanup(self, signum, frame):
         self.running = False
@@ -80,30 +84,33 @@ class Handler(object):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Bridge Mitsi and MQTT')
+    parser = argparse.ArgumentParser(
+                        description='Monitor & control a Mitsubishi heatpump '
+                                    'via MQTT.',
+                        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--mqtt-host',
                         default='localhost', help='MQTT broker')
-#    parser.add_argument('--mqtt-port',
-#                        default='1883', type=int, help='MQTT port')
+    parser.add_argument('--mqtt-port',
+                        default='1883', type=int, help='MQTT port')
     parser.add_argument('--mqtt-prefix',
                         default='mqmitsi',
-                        help='MQTT topic prefix prepended to messages')
+                        help='MQTT topic prefix prepended to messages.')
     parser.add_argument('--serial-port',
                         default='/dev/ttyAMA0',
-                        help='Serial device to communicate on')
+                        help='Serial device to communicate on.')
     parser.add_argument('--log',
-                        help='Set log level. Defaults to WARNING')
+                        help='Set log level.',
+                        default='WARNING')
     args = parser.parse_args()
 
     log = logging.getLogger()
-    log.setLevel(logging.DEBUG)
+    log.setLevel(args.log)
     console = logging.StreamHandler()
     formatter = logging.Formatter('%(asctime)-15s %(levelname)-8s %(message)s')
     console.setFormatter(formatter)
-    console.setLevel(logging.DEBUG)
+    console.setLevel(args.log)
     log.addHandler(console)
-    if args.log:
-        console.setLevel(args.log)
 
-    h = Handler(args.serial_port, broker=args.mqtt_host, prefix=args.mqtt_prefix)
+    h = Handler(args.serial_port, broker=args.mqtt_host,
+                prefix=args.mqtt_prefix, broker_port=args.mqtt_port)
     h.run()


### PR DESCRIPTION
(I would normally break this down into many commits, however the way it evolved as I hacked on my heatpump automation meant it got all bundled together!)

## Lookup Dictionaries

 - Moved the lookup dictionaries to their own file (`mitsi_lookup.py`). This is so that other services can easily consult these values for their own use. (e.g. informing home automation systems what different modes/temps/etc it can set a heatpump unit to).

 - Adding `TEMP` lookup values for half-degree increments. I discovered these as my remote control is set in Fahrenheit, and at some temperatures it would cause `TEMP` lookup exceptions and `mitsi.py` would crash.

 - Adding error handling when a value doesn't existing in a dictionary. This is largely to help developers of future features.

 - Adding an extra input to `LookupDict()`, which provides the name of the dictionary (there doesn't seem to be a way in Python to retrieve the variable name an object is assigned to). Without it, when a lookup fails it's not obvious *which* dictionary is failing.


## Various Changes

- A new `map_set_packet_to_attributes()` method, which dynamically maps `Packet()` to `HeatPump()` attributes. The old approach didn't make use of the `CONTROL_PACKET_POSITIONS` dictionary. The benefit of this new method is that any new attributes added in future will be dynamically picked up without changes to `loop()` etc.

- Support setting a custom MQTT broker port with `--mqtt-port`.

- Replace wildcard imports with specific imports.

- Basic argument parsing and log-level setting when running `mitsi.py` directly.

## Documentation & Clarifications

 - Extended `README.md` with examples.

 - Various method docstrings.

 - Renamed `self.attributes` to `self.reported_attributes` to simply distinguish the list of `HeatPump()` attributes we are monitoring, from all the attributes the object has. (I had incorrectly presumed `self.attributes` was an in-built method, and it confused me for a while!).

- A few extra logging calls to help debugging.

- Made `--help` show the default values.
