### PR TITLE
Update mitsi_lookup.py to include 0x00 for DIR

### DIFF
--- a/mitsi_lookup.py
+++ b/mitsi_lookup.py
@@ -114,6 +114,7 @@ VANE = LookupDict(
 
 DIR = LookupDict(
     {
+        "NA": 0x00,
         "<<": 0x01,
         "<": 0x02,
         "|": 0x03,


### PR DESCRIPTION
Updated DIR to include a 0x00 lookup for systems without vane.
Without this value MQTT doesn't connect/update as its got a None value in a field.